### PR TITLE
Add using System.Linq to Extension.g.cs

### DIFF
--- a/MySourceGenerator.cs
+++ b/MySourceGenerator.cs
@@ -140,6 +140,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
 using System.Text;
+using System.Linq;
 internal static class Extensions
 {{
 {string.Join(Environment.NewLine, GetList(others, xx => xx.Code))}


### PR DESCRIPTION
The generatede code uses the First() linq expression but dose not use System.Linq.

Current workaround is to use global using.